### PR TITLE
add kafka producer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.31",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2110,36 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da18026aad1c24033da3da726200de7e911e75c2e2cc2f77ffb9b4502720faae"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.5.0+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb0676c2112342ac7165decdedbc4e7086c0af384479ccce534546b10687a5d"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2591,6 +2652,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rayon",
+ "rdkafka",
  "rusty-hook",
  "self_update",
  "serde_json",
@@ -3276,9 +3338,11 @@ dependencies = [
  "anyhow",
  "bincode",
  "indexmap 2.0.0",
+ "lazy_static",
  "once_cell",
  "parking_lot",
  "rayon",
+ "rdkafka",
  "rocksdb",
  "serde",
  "serial_test",
@@ -3725,6 +3789,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4264,6 +4345,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,6 +252,9 @@ optional = true
 version = "2.7"
 features = [ "json" ]
 
+[dependencies.rdkafka]
+version = "0.33.2"
+
 [dev-dependencies.bincode]
 version = "1.3"
 

--- a/ledger/store/Cargo.toml
+++ b/ledger/store/Cargo.toml
@@ -119,3 +119,9 @@ version = "3.7"
 
 [dev-dependencies.tracing-test]
 version = "0.2"
+
+[dependencies.rdkafka]
+version = "0.33.2"
+
+[dependencies.lazy_static]
+version = "1.4.0"

--- a/ledger/store/src/helpers/kafka/config.rs
+++ b/ledger/store/src/helpers/kafka/config.rs
@@ -28,6 +28,12 @@ pub struct KafkaProducer {
     producer: BaseProducer,
 }
 
+impl Default for KafkaProducer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KafkaProducer {
     pub fn new() -> Self {
         let producer: BaseProducer =
@@ -41,8 +47,8 @@ impl KafkaProducerTrait for KafkaProducer {
         for i in 1..100 {
             println!("sending message");
             self.producer
-            .send(BaseRecord::to(topic).key(key).payload(&format!("{}-{}", value, i)))
-            .expect("failed to send message");
+                .send(BaseRecord::to(topic).key(key).payload(&format!("{}-{}", value, i)))
+                .expect("failed to send message");
             thread::sleep(Duration::from_secs(3));
         }
     }

--- a/ledger/store/src/helpers/kafka/config.rs
+++ b/ledger/store/src/helpers/kafka/config.rs
@@ -44,6 +44,9 @@ impl KafkaProducer {
 
 impl KafkaProducerTrait for KafkaProducer {
     fn emit_event(&self, key: &str, value: &str, topic: &str) {
+        //  for i in 1..length of kafka queue iterate thru the kafka queue and insert that as parameter
+        // jk no for loop here cuz we iterate in the finish_atomic function
+        // self.producer send @mia
         for i in 1..100 {
             println!("sending message");
             self.producer

--- a/ledger/store/src/helpers/kafka/kafka.rs
+++ b/ledger/store/src/helpers/kafka/kafka.rs
@@ -1,0 +1,49 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use lazy_static::lazy_static;
+use rdkafka::{
+    producer::{BaseProducer, BaseRecord},
+    ClientConfig,
+};
+use std::{thread, time::Duration};
+
+pub struct KafkaProducer {
+    producer: BaseProducer,
+}
+
+impl KafkaProducer {
+    pub fn new() -> Self {
+        let producer: BaseProducer =
+            ClientConfig::new().set("bootstrap.servers", "localhost:9092").create().expect("Producer creation error");
+
+        KafkaProducer { producer }
+    }
+
+    pub fn emit_event(&self, event_data: &str, topic: &str) {
+        for i in 1..100 {
+            println!("sending message");
+
+            self.producer
+                .send(BaseRecord::to(topic).key(&format!("key-{}", event_data)).payload(&format!("value-{}", i)))
+                .expect("failed to send message");
+
+            thread::sleep(Duration::from_secs(3));
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref KAFKA_PRODUCER: KafkaProducer = KafkaProducer::new();
+}

--- a/ledger/store/src/helpers/kafka/kafka_queue.rs
+++ b/ledger/store/src/helpers/kafka/kafka_queue.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::helpers::kafka::KAFKA_PRODUCER;
+use crate::helpers::kafka::KafkaProducerTrait;
 pub struct KafkaQueue {
     pub messages: Vec<(Vec<u8>, Vec<u8>)>,
 }
@@ -29,12 +29,14 @@ impl KafkaQueue {
         self.messages.push((key, value));
     }
 
-    pub fn send_messages(&self, topic: &str) {
+    pub fn send_messages(&self, producer: &impl KafkaProducerTrait, topic: &str) {
         for (key, value) in &self.messages {
-            KAFKA_PRODUCER.emit_event(&String::from_utf8_lossy(&value), topic);
+            let key_str = String::from_utf8_lossy(key);
+            let value_str = String::from_utf8_lossy(value);
+            producer.emit_event(&key_str, &value_str, topic);
         }
     }
-
+    
     #[cfg(test)]
     pub fn get_messages(&self) -> &Vec<(Vec<u8>, Vec<u8>)> {
         &self.messages

--- a/ledger/store/src/helpers/kafka/kafka_queue.rs
+++ b/ledger/store/src/helpers/kafka/kafka_queue.rs
@@ -17,12 +17,15 @@ pub struct KafkaQueue {
     pub messages: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
-impl KafkaQueue {
+impl Default for KafkaQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
+impl KafkaQueue {
     pub fn new() -> Self {
-        KafkaQueue {
-            messages: Vec::new(),
-        }
+        KafkaQueue { messages: Vec::new() }
     }
 
     pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>) {
@@ -30,13 +33,14 @@ impl KafkaQueue {
     }
 
     pub fn send_messages(&self, producer: &impl KafkaProducerTrait, topic: &str) {
+        // pass a producer argument in here so that we can use a mock producer for testing rather than always using the global instance
         for (key, value) in &self.messages {
             let key_str = String::from_utf8_lossy(key);
             let value_str = String::from_utf8_lossy(value);
             producer.emit_event(&key_str, &value_str, topic);
         }
     }
-    
+
     #[cfg(test)]
     pub fn get_messages(&self) -> &Vec<(Vec<u8>, Vec<u8>)> {
         &self.messages

--- a/ledger/store/src/helpers/kafka/kafka_queue.rs
+++ b/ledger/store/src/helpers/kafka/kafka_queue.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use crate::helpers::kafka::KafkaProducerTrait;
+#[derive(Debug)]
 pub struct KafkaQueue {
     pub messages: Vec<(Vec<u8>, Vec<u8>)>,
 }
+// make messages the same datatype as atomic batch
 
 impl Default for KafkaQueue {
     fn default() -> Self {

--- a/ledger/store/src/helpers/kafka/kafka_queue.rs
+++ b/ledger/store/src/helpers/kafka/kafka_queue.rs
@@ -12,6 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod kafka;
-pub use kafka::*;
-pub mod kafka_queue;
+use crate::helpers::kafka::KAFKA_PRODUCER;
+pub struct KafkaQueue {
+    pub messages: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+impl KafkaQueue {
+
+    pub fn new() -> Self {
+        KafkaQueue {
+            messages: Vec::new(),
+        }
+    }
+
+    pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>) {
+        self.messages.push((key, value));
+    }
+
+    pub fn send_messages(&self, topic: &str) {
+        for (key, value) in &self.messages {
+            KAFKA_PRODUCER.emit_event(&String::from_utf8_lossy(&value), topic);
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_messages(&self) -> &Vec<(Vec<u8>, Vec<u8>)> {
+        &self.messages
+    }
+}

--- a/ledger/store/src/helpers/kafka/mod.rs
+++ b/ledger/store/src/helpers/kafka/mod.rs
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod kafka;
-pub use kafka::*;
+pub mod config;
+pub use config::*;
 pub mod kafka_queue;

--- a/ledger/store/src/helpers/kafka/mod.rs
+++ b/ledger/store/src/helpers/kafka/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod kafka;
+pub use kafka::*;

--- a/ledger/store/src/helpers/mod.rs
+++ b/ledger/store/src/helpers/mod.rs
@@ -15,7 +15,7 @@
 pub mod memory;
 #[cfg(feature = "rocks")]
 pub mod rocksdb;
-
+pub mod kafka;
 use console::network::prelude::*;
 
 use core::{borrow::Borrow, hash::Hash};

--- a/ledger/store/src/helpers/mod.rs
+++ b/ledger/store/src/helpers/mod.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod kafka;
 pub mod memory;
 #[cfg(feature = "rocks")]
 pub mod rocksdb;
-pub mod kafka;
 use console::network::prelude::*;
 
 use core::{borrow::Borrow, hash::Hash};

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -35,34 +35,6 @@ pub struct DataMap<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOw
 
 use crate::helpers::kafka::kafka_queue::KafkaQueue;
 
-// struct KafkaQueue {
-//     messages: Vec<(Vec<u8>, Vec<u8>)>,
-// }
-
-// impl KafkaQueue {
-
-//     pub fn new() -> Self {
-//         KafkaQueue {
-//             messages: Vec::new(),
-//         }
-//     }
-
-//     pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>) {
-//         self.messages.push((key, value));
-//     }
-
-//     pub fn send_messages(&self, topic: &str) {
-//         for (key, value) in &self.messages {
-//             KAFKA_PRODUCER.emit_event(&String::from_utf8_lossy(&value), topic);
-//         }
-//     }
-
-//     #[cfg(test)]
-//     pub fn get_messages(&self) -> &Vec<(Vec<u8>, Vec<u8>)> {
-//         &self.messages
-//     }
-// }
-
 impl<
     'a,
     K: 'a + Copy + Clone + Debug + PartialEq + Eq + Hash + Serialize + DeserializeOwned + Send + Sync,


### PR DESCRIPTION
Adding simple rust baseproducer to just send messages in its own function in a loop. Not yet added to any `atomic_write` functions.